### PR TITLE
Fix contact iframe load handler

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -122,7 +122,6 @@ export default async function ContactPage({ searchParams }: PageProps) {
               <iframe
                 id="JotFormIFrame-bespoke-ethos-contact"
                 title="Bespoke Ethos Contact Form"
-                onLoad="window.parent.scrollTo(0,0)"
                 allowFullScreen
                 allow="geolocation; microphone; camera"
                 src="https://form.jotform.com/bespoke-ethos-contact"
@@ -131,21 +130,38 @@ export default async function ContactPage({ searchParams }: PageProps) {
                   minWidth: "100%",
                   height: "541px",
                   border: "none",
+                  borderRadius: "16px",
+                  boxShadow:
+                    "0 10px 40px rgba(0,0,0,0.12), 0 4px 16px rgba(0,0,0,0.06)",
                 }}
               />
               <script type="text/javascript">
-                {`var ifr = document.getElementById("JotFormIFrame-bespoke-ethos-contact");
-                if (ifr) {
-                  var src = ifr.src;
-                  var iframeParams = [];
-                  if (window.location.href && window.location.href.indexOf("?") > -1) {
-                    iframeParams = iframeParams.concat(window.location.href.substr(window.location.href.indexOf("?") + 1).split('&'));
+                {`(function() {
+                  var ifr = document.getElementById("JotFormIFrame-bespoke-ethos-contact");
+                  if (ifr) {
+                    var src = ifr.src;
+                    var iframeParams = [];
+                    if (window.location.href && window.location.href.indexOf("?") > -1) {
+                      iframeParams = iframeParams.concat(window.location.href.substr(window.location.href.indexOf("?") + 1).split('&'));
+                    }
+                    if (iframeParams.length) {
+                      src = src + "?" + iframeParams.join('&');
+                      ifr.src = src;
+                    }
+
+                    var scrollParentToTop = function() {
+                      try {
+                        if (window.parent && typeof window.parent.scrollTo === "function") {
+                          window.parent.scrollTo(0, 0);
+                        }
+                      } catch (err) {
+                        // Ignore cross-origin access errors
+                      }
+                    };
+
+                    ifr.addEventListener("load", scrollParentToTop, { once: true });
                   }
-                  if (iframeParams.length) {
-                    src = src + "?" + iframeParams.join('&');
-                    ifr.src = src;
-                  }
-                }`}
+                })();`}
               </script>
             </div>
 


### PR DESCRIPTION
## Summary
- prevent the contact iframe onLoad attribute type error by moving scroll-to-top behavior into a guarded inline script
- keep querystring propagation for the Jotform embed while adding a subtle rounded/shadow treatment to the iframe container

## Testing
- pnpm build *(fails to fetch Google Fonts in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6926f86b94f483268e03b9dcd201b8b4)