### PR TITLE
Refine Alex story media layout and flagship heading

### DIFF
--- a/src/app/_sections/alex-molly-story/index.tsx
+++ b/src/app/_sections/alex-molly-story/index.tsx
@@ -23,14 +23,14 @@ export function AlexMollyStory() {
                 {/* Main image container - CLICKABLE */}
                 <button
                   onClick={() => setIsImageEnlarged(true)}
-                  className="relative aspect-[4/3] w-full overflow-hidden rounded-2xl shadow-2xl border border-accent-200/50 dark:border-accent-800/50 cursor-zoom-in hover:shadow-3xl transition-shadow duration-300 group"
+                  className="relative aspect-[3/4] sm:aspect-[4/3] w-full overflow-hidden rounded-2xl shadow-2xl border border-accent-200/50 dark:border-accent-800/50 cursor-zoom-in hover:shadow-3xl transition-shadow duration-300 group"
                   aria-label="Click to enlarge Alex's photo with Molly on screen"
                 >
                   <Image
                     src="/assets/Real-Customers/Alex-with-Molly.jpg"
                     alt="Alex with laptop showing Molly AI tutor interface"
                     fill
-                    className="object-cover group-hover:scale-105 transition-transform duration-500"
+                    className="object-cover object-[50%_32%] sm:object-center group-hover:scale-105 transition-transform duration-500"
                     sizes="(max-width: 1024px) 100vw, 50vw"
                     priority
                   />
@@ -72,7 +72,7 @@ export function AlexMollyStory() {
                   Why we do this:
                 </p>
                 <div className="flex items-start gap-5 bg-gradient-to-br from-accent-50/80 to-accent-100/40 dark:from-accent-950/40 dark:to-accent-900/20 p-5 rounded-xl border border-accent-200/60 dark:border-accent-800/60 shadow-md">
-                  <div className="flex-shrink-0 w-20 h-20 relative">
+                  <div className="flex-shrink-0 w-24 h-24 sm:w-28 sm:h-28 relative">
                     <Image
                       src="/assets/we-heart-founders-mug.avif"
                       alt="We love founders mug with heart icon"

--- a/src/app/_sections/flagship-carousel/index.tsx
+++ b/src/app/_sections/flagship-carousel/index.tsx
@@ -155,7 +155,7 @@ export const FlagshipCarousel: React.FC = () => {
   const radius = FACE_SIZE / (2 * Math.tan(Math.PI / faceCount)); // radius tuned to face size
 
   return (
-    <div className="py-12 sm:py-16 bg-surface-primary dark:bg-dark-surface-primary">
+    <div className="pt-8 pb-12 sm:pt-10 sm:pb-16 bg-surface-primary dark:bg-dark-surface-primary">
       <style>{`
         @keyframes rotatingGlow {
           0% {
@@ -199,17 +199,17 @@ export const FlagshipCarousel: React.FC = () => {
           animation: rotatingGlow 6s ease-in-out infinite;
         }
       `}</style>
-      <div className="container mx-auto px-4 sm:px-6 text-center">
-        <p className="mb-2 text-sm italic text-muted-foreground text-text-secondary dark:text-dark-text-secondary">
-          Bespoke Solutions
-        </p>
-        <h2 className="text-black dark:text-white mb-8 sm:mb-12 font-accent" style={{ fontSize: 'clamp(1.05rem, 1.6vw, 1.5rem)' }}>
-          Flagship Collection
-        </h2>
-        <div className="flex justify-center items-center perspective-[1000px] h-[420px] sm:h-[470px]">
-          <div
-            ref={carouselRef}
-            className="relative preserve-3d transition-transform duration-1000 ease-in-out carousel-cube-container"
+        <div className="container mx-auto px-4 sm:px-6 text-center">
+          <p className="mb-1 text-sm font-semibold tracking-wide uppercase text-muted-foreground text-text-secondary dark:text-dark-text-secondary">
+            Bespoke Solutions
+          </p>
+          <h2 className="text-black dark:text-white mb-8 sm:mb-12 font-hero-accent text-3xl sm:text-4xl font-extrabold tracking-tight">
+            Flagship Collection
+          </h2>
+          <div className="flex justify-center items-center perspective-[1000px] h-[420px] sm:h-[470px]">
+            <div
+              ref={carouselRef}
+              className="relative preserve-3d transition-transform duration-1000 ease-in-out carousel-cube-container"
             style={{
               width: "min(90vw, 340px)",
               height: "min(90vw, 340px)",


### PR DESCRIPTION
## Summary
- adjust the Alex & Molly photo container to preserve the face on mobile/tablet/desktop and enlarge the founders mug badge
- tighten flagship/Bespoke Solutions spacing and boost the heading size to reduce empty space

## Testing
- npm run lint *(fails: existing react/no-unescaped-entities errors in other files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69270ce4b7788326a1f43413f3a82c1f)